### PR TITLE
Break long words in product descriptions

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Setlist",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "images": [
     {
       "variable": "logo",

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -40,6 +40,7 @@ h2.product-price
   font-family: $secondary-font
   font-size: 16px
   line-height: 24px
+  word-break: break-word
 
   @media screen and (max-width: $break-medium)
     margin: 0 auto


### PR DESCRIPTION
Super long strings in product descriptions were causing layout issues